### PR TITLE
Enable profiles without tTEM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,13 @@ pip install -e .
 ### 🌍 Try and read one of the examples
 Go to the Examples folder. It's easier to follow with a Jupyter notebook
 
-#### Run the Kakuma.ipynb 
+#### Run the Kakuma.ipynb
 
-### 🧱👷‍♂️ Create your own! 
+### 🧱👷‍♂️ Create your own!
+
+### Profiles without tTEM data
+
+`createProfiles` can now be called with `ttem_model_idx=None` to generate the
+profile geometry using only sTEM or Profiler soundings. This allows projecting
+these soundings along a profile even when no tTEM models are available within
+the search radius.


### PR DESCRIPTION
## Summary
- allow creating base profiles when no tTEM data are available
- support geometry creation from sTEM or profiler soundings
- document new usage in README

## Testing
- `python -m py_compile src/ProfilePlotter/ProfilePlotter.py`

------
https://chatgpt.com/codex/tasks/task_e_6861416a0e50832e9e096776245fbf5a