### PR TITLE
Enable profiles without tTEM models

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ pip install -e .
 ### 🌍 Try and read one of the examples
 Go to the Examples folder. It's easier to follow with a Jupyter notebook
 
-#### Run the Kakuma.ipynb 
+#### Run the Kakuma.ipynb
 
-### 🧱👷‍♂️ Create your own! 
+### 🧱👷‍♂️ Create your own!
+
+### Profiles without tTEM data
+
+`createProfiles` can now be called with `ttem_model_idx=None` to generate the
+profile geometry using only sTEM or Profiler soundings. This allows projecting
+these soundings along a profile even when no tTEM models are available within
+the search radius. Internally this uses a new `createProfileBase` method which
+builds the profile geometry from any available data types.

--- a/src/ProfilePlotter/ProfilePlotter.py
+++ b/src/ProfilePlotter/ProfilePlotter.py
@@ -300,41 +300,109 @@ class Model:
         # Set weights to 0 for points outside the specified radius
         weights[dists > interp_radius] = 0
 
-        # Normalize weights for each grid point
-        weights /= np.sum(weights, axis=0)
+        # Normalize weights for each grid point and avoid division by zero
+        denom = np.sum(weights, axis=0)
+        with np.errstate(divide="ignore", invalid="ignore"):
+            weights = np.where(denom == 0, 0, weights / denom)
 
         # Interpolate values using weighted average
         zi = np.sum(z[:, np.newaxis] * weights, axis=0)
 
+        # mark grid points with no nearby data as NaN
+        zi[denom == 0] = np.nan
+
         return zi
 
     def interpLIN(self, x, z):
-  
-        # Create interpolation function, excluding nan values
-        interp_func = interp1d(x[~np.isnan(z)], z[~np.isnan(z)],
-                               kind='linear', fill_value="extrapolate")
+
+        valid = ~np.isnan(z)
+        if not np.any(valid):
+            return np.zeros_like(z)
+
+        # Create interpolation function using available values
+        interp_func = interp1d(x[valid], z[valid], kind="linear",
+                               fill_value="extrapolate")
         zi = z.copy()
-        zi[np.isnan(z)] = interp_func(x[np.isnan(z)])
+        zi[~valid] = interp_func(x[~valid])
 
         if np.isnan(zi[-1]):
             zi[-1] = zi[-2]
 
         return zi
 
-    def createProfiles(self, ttem_model_idx, profile_idx='all', model_spacing=10, interp_radius=40):
-        #this only create profiles that contain tTEM models
-        #we need to create an option where the interpolation method can be chosen: nearest neighbout, krigging, IDW...
+    def createProfileBase(self, profile_idx='all', model_spacing=10, interp_radius=40):
+        """Generate base profile geometry without interpolating tTEM models.
+
+        This method computes the interpolated profile coordinates (``xi`` and
+        ``yi``) and the cumulative distance along the profile. Elevations are
+        estimated using all loaded model types (tTEM, sTEM and Profiler) if
+        available. It is intended for cases where no tTEM models are present but
+        sTEM or profiler soundings should still be projected onto the profile.
+        """
+
         if profile_idx == 'all':
-            profile_idx = range(0, len(self.profiles))
-        elif type(profile_idx) != list:
+            profile_idx = range(len(self.profiles))
+        elif not isinstance(profile_idx, list):
             profile_idx = [profile_idx]
+
+        # gather coordinates and elevations from all available model types
+        x_all, y_all, elev_all = [], [], []
+        for mod in self.ttem_models + self.stem_models + self.profiler_models:
+            x_all.extend(mod['x'])
+            y_all.extend(mod['y'])
+            elev_all.extend(mod['elev'])
+
+        if len(x_all) > 0:
+            x_all = np.asarray(x_all)
+            y_all = np.asarray(y_all)
+            elev_all = np.asarray(elev_all)
+
+        for idx in profile_idx:
+            x_p = self.profiles[idx]['x']
+            y_p = self.profiles[idx]['y']
+
+            xi, yi, dists = self.interpCoords(x_p, y_p, distance=model_spacing)
+
+            if len(x_all) > 0:
+                elev_new = self.interpIDW(x_all, y_all, elev_all, xi, yi,
+                                          power=2, interp_radius=interp_radius)
+                if np.all(np.isnan(elev_new)):
+                    elev_new = np.zeros_like(xi)
+                else:
+                    elev_new = self.interpLIN(dists, elev_new)
+            else:
+                elev_new = np.zeros_like(xi)
+
+            self.profiles[idx].update({'elev': elev_new,
+                                       'distances': dists,
+                                       'xi': xi,
+                                       'yi': yi})
+
+    def createProfiles(self, ttem_model_idx=None, profile_idx='all', model_spacing=10, interp_radius=40):
+        """Interpolate model data along profiles.
+
+        If ``ttem_model_idx`` is ``None`` or no tTEM models are loaded, only the
+        base profile geometry is created using :func:`createProfileBase`.
+        """
+
+        if profile_idx == 'all':
+            profile_idx = range(len(self.profiles))
+        elif not isinstance(profile_idx, list):
+            profile_idx = [profile_idx]
+
+        if ttem_model_idx is None or len(self.ttem_models) == 0:
+            # Only compute the profile geometry based on available models
+            self.createProfileBase(profile_idx=profile_idx,
+                                   model_spacing=model_spacing,
+                                   interp_radius=interp_radius)
+            return
 
         rhos = self.ttem_models[ttem_model_idx]['rhos']
         depths = self.ttem_models[ttem_model_idx]['depths']
         x = self.ttem_models[ttem_model_idx]['x']
         y = self.ttem_models[ttem_model_idx]['y']
-        elev = self.ttem_models[ttem_model_idx]['elev'] 
-        doi = self.ttem_models[ttem_model_idx]['doi_standard'] 
+        elev = self.ttem_models[ttem_model_idx]['elev']
+        doi = self.ttem_models[ttem_model_idx]['doi_standard']
 
         for idx in profile_idx:
             # Add debug statement to print the profile filename
@@ -366,15 +434,17 @@ class Model:
             #print(f"dists: {dists}")
             #print(f"elev: {elev}")
 
-            elev_new = self.interpIDW(x, y, elev, xi, yi, power=2, interp_radius=interp_radius)
-
-
+            elev_new = self.interpIDW(x, y, elev, xi, yi, power=2,
+                                      interp_radius=interp_radius)
 
             # Debug statement before calling interpLIN
             #print(f"Interpolated elevation: {elev_new}")
-            
+
             try:
-                elev_new = self.interpLIN(dists, elev_new)
+                if np.all(np.isnan(elev_new)):
+                    elev_new = np.zeros_like(xi)
+                else:
+                    elev_new = self.interpLIN(dists, elev_new)
             except ValueError as e:
                 print(f"Error occurred with profile: {filename}")
                 print(f"dists: {dists}")


### PR DESCRIPTION
## Summary
- allow creating base profiles when no tTEM data are available
- support geometry creation from sTEM or profiler soundings
- document new usage in README

## Testing
- `python -m py_compile src/ProfilePlotter/ProfilePlotter.py`


------
https://chatgpt.com/codex/tasks/task_e_6861416a0e50832e9e096776245fbf5a